### PR TITLE
Limit internal state var TSTRAT_Adj to RRTMG simulations only

### DIFF
--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -915,6 +915,7 @@ CONTAINS
                                                       RC=STATUS  )
     _VERIFY(STATUS)
 
+#if defined( RRTMG )
     ! Stratospheric temperature adjustment accumulated when using RRTMG
     call MAPL_AddInternalSpec(GC, &
        SHORT_NAME         = 'TSTRAT_ADJ',&
@@ -927,6 +928,7 @@ CONTAINS
                                                       RC=STATUS  )
     _VERIFY(STATUS)
 
+#endif
     ! Additional outputs useful for unit conversions and post-processing analysis
     call MAPL_AddInternalSpec(GC, &
        SHORT_NAME         = 'AREA',  &


### PR DESCRIPTION
This PR prevents including RRTMG-only internal state variable in non-RRTMG simulations.